### PR TITLE
Suite: Add dry-run for scheduling suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,5 +59,4 @@ curl --location --request POST 'http://localhost:8082/suite/' \
  }'
 ```
 
-
-
+POST `/suite/dryrun`: dry runs a suite.

--- a/README.md
+++ b/README.md
@@ -37,9 +37,14 @@ Returns `{"root": "success"}`.
 ### Route `/suite`
 
 POST `/suite/`: schedules a run.
+
+Two query parameters: 
+- `dry_run` (boolean) - Do a dry run; do not schedule anything.
+- `logs` (boolean) - Send scheduling logs in response.
+
 Example:
 ```
-curl --location --request POST 'http://localhost:8082/suite/' \
+curl --location --request POST 'http://localhost:8082/suite?dry_run=false&logs=true' \
 --header 'Content-Type: application/json' \
 --data-raw '{
          "--ceph": "wip-dis-testing-2",
@@ -59,4 +64,3 @@ curl --location --request POST 'http://localhost:8082/suite/' \
  }'
 ```
 
-POST `/suite/dryrun`: dry runs a suite.

--- a/src/routes/suite.py
+++ b/src/routes/suite.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, HTTPException
-from services.suite import run, dry_run
+from services.suite import run
 from schemas.suite import SuiteArgs
 import logging
 
@@ -12,19 +12,10 @@ router = APIRouter(
 )
 
 @router.post("/", status_code=200)
-def create_run(args: SuiteArgs):
+def create_run(args: SuiteArgs, dry_run: bool = False, logs: bool = False):
     try:
         args = args.dict(by_alias=True)
-        results = run(args)
-        return {"run": results}
-    except Exception as exc:
-        raise HTTPException(status_code=404, detail=repr(exc))
-
-@router.post("/dryrun", status_code=200)
-def create_dryrun(args: SuiteArgs):
-    try:
-        args = args.dict(by_alias=True)
-        result = dry_run(args)
-        return result
+        results = run(args, dry_run, logs)
+        return results
     except Exception as exc:
         raise HTTPException(status_code=404, detail=repr(exc))

--- a/src/routes/suite.py
+++ b/src/routes/suite.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, HTTPException
-from services.suite import run
+from services.suite import run, dry_run
 from schemas.suite import SuiteArgs
 import logging
 
@@ -17,5 +17,14 @@ def create_run(args: SuiteArgs):
         args = args.dict(by_alias=True)
         results = run(args)
         return {"run": results}
+    except Exception as exc:
+        raise HTTPException(status_code=404, detail=repr(exc))
+
+@router.post("/dryrun", status_code=200)
+def create_dryrun(args: SuiteArgs):
+    try:
+        args = args.dict(by_alias=True)
+        result = dry_run(args)
+        return result
     except Exception as exc:
         raise HTTPException(status_code=404, detail=repr(exc))

--- a/src/services/helpers.py
+++ b/src/services/helpers.py
@@ -8,7 +8,7 @@ def logs_run(func, args):
     and return logs printed during the execution of the function.
     """
     id = str(uuid.uuid4())
-    log_file = f'/archive_dir/{id}.log'
+    log_file = f'/tmp/{id}.log'
 
     teuthology_process = Process(
         target=_execute_with_logs, args=(func, args, log_file,))

--- a/src/services/helpers.py
+++ b/src/services/helpers.py
@@ -1,0 +1,31 @@
+import uuid, os
+from multiprocessing import Process
+import teuthology
+
+def logs_run(func, args):
+    """
+    Run the command function in a seperate process (to isolate logs),
+    and return logs printed during the execution of the function.
+    """
+    id = str(uuid.uuid4())
+    log_file = f'/archive_dir/{id}.log'
+
+    teuthology_process = Process(
+        target=_execute_with_logs, args=(func, args, log_file,))
+    teuthology_process.start()
+    teuthology_process.join()
+
+    logs = ""
+    with open(log_file) as f:
+        logs = f.readlines()
+    if os.path.isfile(log_file): 
+        os.remove(log_file)
+    return logs
+
+def _execute_with_logs(func, args, log_file):
+    """
+    To store logs, set a new FileHandler for teuthology root logger
+    and then execute the command function.
+    """
+    teuthology.setup_log_file(log_file)
+    func(args)

--- a/src/services/suite.py
+++ b/src/services/suite.py
@@ -27,6 +27,16 @@ def run(args):
         log.error("teuthology.suite.main failed with the error: " + repr(exc))
         raise
 
+def dry_run(args):
+    try:
+        args['--dry-run'] = True
+        results = teuthology.suite.main(args)
+        log.debug(results)
+        return
+    except Exception as exc:
+        log.error("teuthology.suite.main failed with the error: " + repr(exc))
+        raise
+
 def get_run_details(run_name):
     """
     Queries paddles to look if run is created.

--- a/src/services/suite.py
+++ b/src/services/suite.py
@@ -1,6 +1,6 @@
 import teuthology.suite
-from multiprocessing import Process
-import logging, requests, uuid, os # Note: import requests after teuthology
+from services.helpers import logs_run
+import logging, requests # Note: import requests after teuthology
 from datetime import datetime
 
 from config import settings
@@ -19,12 +19,12 @@ def run(args, dry_run: bool, send_logs: bool):
         args["--timestamp"] = datetime.now().strftime('%Y-%m-%d_%H:%M:%S')
         if dry_run:
             args['--dry-run'] = True
-            logs = logs_run(args)
+            logs = logs_run(teuthology.suite.main, args)
             return { "run": {}, "logs": logs }
 
         logs = []
         if send_logs:
-            logs = logs_run(args)
+            logs = logs_run(teuthology.suite.main, args)
         else:
             teuthology.suite.main(args)
 
@@ -43,32 +43,6 @@ def run(args, dry_run: bool, send_logs: bool):
     except Exception as exc:
         log.error("teuthology.suite.main failed with the error: " + repr(exc))
         raise
-
-def logs_run(args):
-    """
-    Schedule suite in a seperate process (to isolate logs).
-    """
-    id = str(uuid.uuid4())
-    log_file = f'/archive_dir/{id}.log'
-
-    teuthology_process = Process(target=run_with_logs, args=(args, log_file,))
-    teuthology_process.start()
-    teuthology_process.join()
-
-    logs = ""
-    with open(log_file) as f:
-        logs = f.readlines()
-    if os.path.isfile(log_file): 
-        os.remove(log_file)
-    return logs
-
-def run_with_logs(args, log_file):
-    """
-    Set a new log file to store logs 
-    and then schedule suite.
-    """
-    teuthology.setup_log_file(log_file)
-    teuthology.suite.main(args)
 
 def get_run_details(run_name):
     """


### PR DESCRIPTION
Add two query params `dry_run` (bool) and `logs` (bool).
If `dry_run` is true, don't schedule suite and return logs (regardless of the value of `logs` param).
If `logs` is true, return logs (for both normal and dry-run).

After scheduling the suite, query paddles for run details. 
If run is not found, throw error. 

To separate logs of two parallel runs, multiprocessing is used. 
**Why multiprocessing?**
For two parallel runs, teuthology was printing logs to the same file, and configuring those runs to print to different files was not working as expected. It was not able to identify difference between the source of logs from those two parallel runs. 
So, I wanted to get a new instance of the teuthology import, for which multiprocessing seemed like a good solution.

----
**Requested changes** 
- [ ] Push dockerfile changes
- [ ] Create log files in /tmp instead. It might not have permissions to access /archive_dir directory or directory path might not exist.